### PR TITLE
Automatically retrieve keys from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ sshenc.sh -p ~/.ssh/id_rsa.pub -p id_rsa-alice.pub -p id_rsa-bob.pub < plain-tex
 
 ### encrypt a file using the public key of a github user
 ```
-sshenc.sh -p <(curl -sf "https://github.com/S2-.keys" | grep ssh-rsa | tail -n1) < plain-text-file.txt
+sshenc.sh -g S2- < plain-text-file.txt
 ```
-this line fetches the first public key for the github user S2- and encrypts the file plain-text-file.txt using this key.
+this line fetches the public keys for the github user S2- and encrypts the file plain-text-file.txt using its key(s).
 
 ### decrypt a file
 ```
@@ -38,10 +38,10 @@ sshenc.sh -s ~/.ssh/id_rsa < encrypted.txt
 ```
 
 ## Notes
-[OpenSSL 1.1.1](https://www.openssl.org/docs/man1.1.1/man1/openssl-enc.html) introduced a not backwards compatible change: the default digest to create a key from the passphrase changed from md5 to sha-256.  
-Also, a new `-iter` parameter to explicitly specify a given number of iterations on the password in deriving the encryption key was added.  
-Before OpenSSL 1.1.1 this option was not available.  
-Since the new parameters are more secure, `sshenc.sh` changed to adopt them, so since 2019-11-26, files encrypted with a previous version of `sshenc.sh` will not decrypt.  
+[OpenSSL 1.1.1](https://www.openssl.org/docs/man1.1.1/man1/openssl-enc.html) introduced a not backwards compatible change: the default digest to create a key from the passphrase changed from md5 to sha-256.
+Also, a new `-iter` parameter to explicitly specify a given number of iterations on the password in deriving the encryption key was added.
+Before OpenSSL 1.1.1 this option was not available.
+Since the new parameters are more secure, `sshenc.sh` changed to adopt them, so since 2019-11-26, files encrypted with a previous version of `sshenc.sh` will not decrypt.
 To do so, use the prevous `sshenc.sh` script, located at [https://sshenc.sh/sshenc-pre1.1.1.sh](https://sshenc.sh/sshenc-pre1.1.1.sh).
 
 ## License

--- a/sshenc.sh
+++ b/sshenc.sh
@@ -85,7 +85,7 @@ if [[ "${#public_key[@]}" > 0 ]]; then
             convertedpubkey=$temp_dir/$(basename "$pubkey").pem
             ssh-keygen -f "$pubkey" -e -m PKCS8 > $convertedpubkey
             #encrypt key with public keys
-            if openssl rsautl -encrypt -pubin -inkey "$convertedpubkey" -in "$temp_file_key" -out $temp_dir/$(basename "$pubkey").key.enc; then
+            if openssl rsautl -encrypt -oaep -pubin -inkey "$convertedpubkey" -in "$temp_file_key" -out $temp_dir/$(basename "$pubkey").key.enc; then
                 echo "-- key"
                 openssl base64 -in $temp_dir/$(basename "$pubkey").key.enc
                 echo "-- /key"
@@ -120,7 +120,7 @@ elif [[ -e "$private_key" ]]; then
 
     decrypted=false
     for key in "${keys[@]}"; do
-        if ((echo "$key" | openssl base64 -d -A | openssl rsautl -decrypt -ssl -inkey "$temp_dir/private_key" >"$temp_file") >/dev/null 2>&1); then
+        if ((echo "$key" | openssl base64 -d -A | openssl rsautl -decrypt -oaep -inkey "$temp_dir/private_key" >"$temp_file") >/dev/null 2>&1); then
             if echo "$cypher" | openssl base64 -d -A | openssl aes-256-cbc -pbkdf2 -iter 100000 -d -pass file:"$temp_file"; then
                 decrypted=true
             fi

--- a/sshenc.sh
+++ b/sshenc.sh
@@ -120,7 +120,7 @@ elif [[ -e "$private_key" ]]; then
 
     decrypted=false
     for key in "${keys[@]}"; do
-        if ((echo "$key" | openssl base64 -d -A | openssl rsautl -decrypt -oaep -inkey "$temp_dir/private_key" >"$temp_file") >/dev/null 2>&1); then
+        if $(echo "$key" | openssl base64 -d -A | openssl rsautl -decrypt -oaep -inkey "$temp_dir/private_key" >"$temp_file" 2>/dev/null); then
             if echo "$cypher" | openssl base64 -d -A | openssl aes-256-cbc -pbkdf2 -iter 100000 -d -pass file:"$temp_file"; then
                 decrypted=true
             fi


### PR DESCRIPTION
Hello

nice software, I added an option to sshenc.sh to automatically retrieve the ssh keys from the github handle.

while I was there i changed some options to make it work with more modern systems (bash 5, openssl 1.1.1d) as the decryption was failing for me

I tested on Linux only but I'll test in mac when i get a hold of those. if anything fails I will fix it as my use-case  requires it
